### PR TITLE
Add noBuild parameter to NuGet pipeline

### DIFF
--- a/pipelines/nuget-package/default-ci-pipeline.yaml
+++ b/pipelines/nuget-package/default-ci-pipeline.yaml
@@ -12,6 +12,7 @@ parameters:
   nugetFeedFromDevops: '/8187f5c9-e9c1-419f-8a5c-98285cf7633c' #GlobalDev
   nugetDevOpsFeedToPublish: '/8187f5c9-e9c1-419f-8a5c-98285cf7633c' #GlobalDev
   pushpackage: '' #set to true or false to override variable "pushpackage". If not set, varibale "pushpackage" is used in template step PUSH = it is not executed
+  noBuild: 'false'
   noUnitTests: 'false'
   verbosityRestore: 'Minimal'
   VersionSuffix: '' #set in case you want to override default semver version (from gitversion)
@@ -49,6 +50,7 @@ jobs:
       nugetFeedFromDevops: '${{ parameters.nugetFeedFromDevops }}'
       verbosityRestore: '${{ parameters.verbosityRestore }}'
       buildConfiguration: '${{ parameters.buildConfiguration }}'
+      noBuild: '${{ parameters.noBuild }}'
 
   - template: templates/test.yaml
     parameters:

--- a/pipelines/nuget-package/templates/build.yaml
+++ b/pipelines/nuget-package/templates/build.yaml
@@ -10,20 +10,22 @@ parameters:
   nugetFeedFromDevops: '! need to be set by pipeline !' #sample value: '/123789456-aaaa-1111-1234-1237894560'
   verbosityRestore: '! need to be set by pipeline !' #sample value: 'Minimal'
   buildConfiguration: '! need to be set by pipeline !' #sample value: 'release'
+  noBuild: '! need to be set by pipeline !' #sample value: 'false'
 
 steps:
 
-- task: DotNetCoreCLI@2
-  displayName: Restore
-  inputs:
-    command: restore
-    projects: '${{ parameters.pathToProjects }}'
-    vstsFeed: '${{ parameters.nugetFeedFromDevops }}'
-    verbosityRestore: '${{ parameters.verbosityRestore }}'
+- ${{ if ne(parameters.noBuild, 'true') }}:
+  - task: DotNetCoreCLI@2
+    displayName: Restore
+    inputs:
+      command: restore
+      projects: '${{ parameters.pathToProjects }}'
+      vstsFeed: '${{ parameters.nugetFeedFromDevops }}'
+      verbosityRestore: '${{ parameters.verbosityRestore }}'
 
-- task: DotNetCoreCLI@2
-  displayName: Build
-  inputs:
-    projects: '${{ parameters.pathToProjects }}'
-    arguments: '--configuration ${{ parameters.buildConfiguration }} --no-restore '
-  condition: succeeded()
+  - task: DotNetCoreCLI@2
+    displayName: Build
+    inputs:
+      projects: '${{ parameters.pathToProjects }}'
+      arguments: '--configuration ${{ parameters.buildConfiguration }} --no-restore '
+    condition: succeeded()


### PR DESCRIPTION
New `noBuild` parameter for the default NuGet pipeline. It is required in scenarios, where project doesn't contain any buildable target.