### PR TITLE
Add noBuild parameter to NuGet pipeline

### DIFF
--- a/ci-build.yaml
+++ b/ci-build.yaml
@@ -16,6 +16,7 @@ jobs:
 - template: pipelines/nuget-package/default-ci-pipeline.yaml
   parameters:
     jobName: 'WithoutBuild'
+    pathToProjects: '$(Build.SourcesDirectory)/src/EmptySampleProject.NoAssembly/EmptySampleProject.NoAssembly.csproj'
     noBuild: 'true'
     noUnitTests: 'true'
 

--- a/ci-build.yaml
+++ b/ci-build.yaml
@@ -12,6 +12,12 @@ jobs:
   parameters:
     jobName: 'BuildWithLinux'
 
+# test pipeline without build and tests
+- template: pipelines/nuget-package/default-ci-pipeline.yaml
+  parameters:
+    noBuild: 'true'
+    noUnitTests: 'true'
+
 # test pipeline with parameters
 - template: pipelines/nuget-package/default-ci-pipeline.yaml
   parameters:

--- a/ci-build.yaml
+++ b/ci-build.yaml
@@ -19,6 +19,7 @@ jobs:
     pathToProjects: '$(Build.SourcesDirectory)/src/EmptySampleProject.NoAssembly/EmptySampleProject.NoAssembly.csproj'
     noBuild: 'true'
     noUnitTests: 'true'
+    pushpackage: true
 
 # test pipeline with parameters
 - template: pipelines/nuget-package/default-ci-pipeline.yaml

--- a/ci-build.yaml
+++ b/ci-build.yaml
@@ -20,6 +20,7 @@ jobs:
     noBuild: 'true'
     noUnitTests: 'true'
     pushpackage: true
+    vmImage: 'windows-2019'
 
 # test pipeline with parameters
 - template: pipelines/nuget-package/default-ci-pipeline.yaml

--- a/ci-build.yaml
+++ b/ci-build.yaml
@@ -15,6 +15,7 @@ jobs:
 # test pipeline without build and tests
 - template: pipelines/nuget-package/default-ci-pipeline.yaml
   parameters:
+    jobName: 'WithoutBuild'
     noBuild: 'true'
     noUnitTests: 'true'
 

--- a/pipelines/nuget-package/default-ci-pipeline.yaml
+++ b/pipelines/nuget-package/default-ci-pipeline.yaml
@@ -12,6 +12,7 @@ parameters:
   nugetFeedFromDevops: '/8187f5c9-e9c1-419f-8a5c-98285cf7633c' #GlobalDev
   nugetDevOpsFeedToPublish: '/8187f5c9-e9c1-419f-8a5c-98285cf7633c' #GlobalDev
   pushpackage: '' #set to true or false to override variable "pushpackage". If not set, varibale "pushpackage" is used in template step PUSH = it is not executed
+  noBuild: 'false'
   noUnitTests: 'false'
   verbosityRestore: 'Minimal'
   VersionSuffix: '' #set in case you want to override default semver version (from gitversion)
@@ -49,6 +50,7 @@ jobs:
       nugetFeedFromDevops: '${{ parameters.nugetFeedFromDevops }}'
       verbosityRestore: '${{ parameters.verbosityRestore }}'
       buildConfiguration: '${{ parameters.buildConfiguration }}'
+      noBuild: '${{ parameters.noBuild }}'
 
   - template: templates/test.yaml
     parameters:

--- a/pipelines/nuget-package/templates/build.yaml
+++ b/pipelines/nuget-package/templates/build.yaml
@@ -14,15 +14,15 @@ parameters:
 
 steps:
 
-- ${{ if ne(parameters.noBuild, 'true') }}:
-  - task: DotNetCoreCLI@2
-    displayName: Restore
-    inputs:
-      command: restore
-      projects: '${{ parameters.pathToProjects }}'
-      vstsFeed: '${{ parameters.nugetFeedFromDevops }}'
-      verbosityRestore: '${{ parameters.verbosityRestore }}'
+- task: DotNetCoreCLI@2
+  displayName: Restore
+  inputs:
+    command: restore
+    projects: '${{ parameters.pathToProjects }}'
+    vstsFeed: '${{ parameters.nugetFeedFromDevops }}'
+    verbosityRestore: '${{ parameters.verbosityRestore }}'
 
+- ${{ if ne(parameters.noBuild, 'true') }}:
   - task: DotNetCoreCLI@2
     displayName: Build
     inputs:

--- a/pipelines/nuget-package/templates/build.yaml
+++ b/pipelines/nuget-package/templates/build.yaml
@@ -10,20 +10,22 @@ parameters:
   nugetFeedFromDevops: '! need to be set by pipeline !' #sample value: '/123789456-aaaa-1111-1234-1237894560'
   verbosityRestore: '! need to be set by pipeline !' #sample value: 'Minimal'
   buildConfiguration: '! need to be set by pipeline !' #sample value: 'release'
+  noBuild: '! need to be set by pipeline !' #sample value: 'false'
 
 steps:
 
-- task: DotNetCoreCLI@2
-  displayName: Restore
-  inputs:
-    command: restore
-    projects: '${{ parameters.pathToProjects }}'
-    vstsFeed: '${{ parameters.nugetFeedFromDevops }}'
-    verbosityRestore: '${{ parameters.verbosityRestore }}'
+- ${{ if ne(parameters.noBuild, 'true') }}:
+  - task: DotNetCoreCLI@2
+    displayName: Restore
+    inputs:
+      command: restore
+      projects: '${{ parameters.pathToProjects }}'
+      vstsFeed: '${{ parameters.nugetFeedFromDevops }}'
+      verbosityRestore: '${{ parameters.verbosityRestore }}'
 
-- task: DotNetCoreCLI@2
-  displayName: Build
-  inputs:
-    projects: '${{ parameters.pathToProjects }}'
-    arguments: '--configuration ${{ parameters.buildConfiguration }} --no-restore '
-  condition: succeeded()
+  - task: DotNetCoreCLI@2
+    displayName: Build
+    inputs:
+      projects: '${{ parameters.pathToProjects }}'
+      arguments: '--configuration ${{ parameters.buildConfiguration }} --no-restore '
+    condition: succeeded()

--- a/src/EmptySampleProject.NoAssembly/EmptySampleProject.NoAssembly.csproj
+++ b/src/EmptySampleProject.NoAssembly/EmptySampleProject.NoAssembly.csproj
@@ -4,8 +4,8 @@
     <TargetFramework>netcoreapp2.2</TargetFramework>
   </PropertyGroup>
 
-  <Target Name="DummyTarget">
-    <Message Text="Message from dummy target." />
-  </Target>
+  <ItemGroup>
+    <Content Include="README.md" />
+  </ItemGroup>
 
 </Project>

--- a/src/EmptySampleProject.NoAssembly/EmptySampleProject.NoAssembly.csproj
+++ b/src/EmptySampleProject.NoAssembly/EmptySampleProject.NoAssembly.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.Build.NoTargets">
+<Project Sdk="Microsoft.Build.NoTargets/1.0.88">
 
   <PropertyGroup>
     <TargetFramework>netcoreapp2.2</TargetFramework>

--- a/src/EmptySampleProject.NoAssembly/EmptySampleProject.NoAssembly.csproj
+++ b/src/EmptySampleProject.NoAssembly/EmptySampleProject.NoAssembly.csproj
@@ -4,4 +4,8 @@
     <TargetFramework>netcoreapp2.2</TargetFramework>
   </PropertyGroup>
 
+  <Target Name="DummyTarget">
+    <Message Text="Message from dummy target." />
+  </Target>
+
 </Project>

--- a/src/EmptySampleProject.NoAssembly/EmptySampleProject.NoAssembly.csproj
+++ b/src/EmptySampleProject.NoAssembly/EmptySampleProject.NoAssembly.csproj
@@ -1,0 +1,7 @@
+<Project Sdk="Microsoft.Build.NoTargets">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp2.2</TargetFramework>
+  </PropertyGroup>
+
+</Project>

--- a/src/EmptySampleProject.NoAssembly/README.md
+++ b/src/EmptySampleProject.NoAssembly/README.md
@@ -1,0 +1,1 @@
+Sample empty repo for CI builds.

--- a/src/readme.md
+++ b/src/readme.md
@@ -1,3 +1,3 @@
 # about this folder
 
-It's a sample C# project for CI build to test build pipelines.
+It's a sample C# projects for CI build to test build pipelines.


### PR DESCRIPTION
New `noBuild` parameter for the default NuGet pipeline. It is required in scenarios, where project doesn't contain any buildable target.